### PR TITLE
[RFR] Fix tests

### DIFF
--- a/cypress/integration/app.spec.js
+++ b/cypress/integration/app.spec.js
@@ -18,8 +18,7 @@ describe('Global app Tests', () => {
         cy.get('input[name="zipcode"]')
             .clear()
             .type('75000');
-        /* the following lines does not terminate the test when running on CI
         cy.get('button[type="submit"]').click();
-        cy.contains('Element updated');*/
+        cy.contains('Element updated');
     });
 });

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "test": "react-scripts test",
         "eject": "react-scripts eject",
         "test:e2e:setup": "cypress install",
-        "test:e2e": "cypress run",
+        "test:e2e": "cypress run --browser chrome",
         "test:e2e:open": "cypress open",
         "test:e2e:ci": "concurrently --kill-others --success=first 'yarn start --progress=false --no-info' 'yarn test:e2e'"
     },


### PR DESCRIPTION
For some reason, `cypress run` with electron behaves like `cypress open`. Might be a cypress bug, fixed when running cypress on chrome.